### PR TITLE
chore: add commitizen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CA Technologies Webpack configuration
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## Demos
 
@@ -82,3 +83,11 @@ export default factory(template, {
     someExtraOption: 'foo',
 });
 ```
+
+
+## Contributing
+
+This project supports `commitizen`. You can use `npm run commit` to run the local instance of `commitizen` or `git cz` if you have it installed globally.
+
+Alternatively, if you are simply using `git commit`, you must follow this format:
+`git commit -m "<type>: <subject>"`

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "react": "^15.4.1",
     "semantic-release": "^6.3.2",
     "webpack": "^1.13.3",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "^1.16.2",
+    "husky": "^0.11.9",
+    "validate-commit-msg": "^2.8.2"
   },
   "scripts": {
     "commit": "git-cz",
@@ -72,9 +74,13 @@
     "test:acceptance": "cd tests/acceptance; webpack --bail; NODE_ENV=production webpack --bail",
     "test:unit": "jest",
     "test": "npm run build; npm run test:acceptance; npm run test:unit",
-    "release": "semantic-release pre && npm publish && semantic-release post"
+    "release": "semantic-release pre && npm publish && semantic-release post",
+    "commitmsg": "validate-commit-msg"
   },
   "config": {
+    "validate-commit-msg": {
+      "types": "conventional-commit-types"
+    },
     "commitizen": {
       "path": "cz-conventional-changelog"
     }

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -9,7 +9,7 @@ import webfonts from './loaders/webfonts';
 import fontgen from './loaders/fontgen';
 import eslint from './preloaders/eslint';
 import baggage from './preloaders/baggage';
-import sourcemap from './preloaders/sourcemap';
+import sourcemap from './preloaders/sourceMap';
 
 export default function (options) {
   return {


### PR DESCRIPTION
This Commit adds `commitizen`, `validate-commit-msg` and `cz-conventional-changelog` functionality to this repo, as per https://rally1.rallydev.com/#/63515825210ud/detail/userstory/78741891276

Commit messages for this project will now have to be structured in this format:
`git commit -m "<type>: <subject>"`

e.g. `git commit -m "chore: add commitizen adapter"`

CC: @alebiavati @shanedasilva @bevanhunt