### PR TITLE
chore(babel): re-organized babel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,7 @@
   "dependencies": {
     "assets-webpack-plugin": "^3.4.0",
     "autoprefixer": "^6.5.0",
-    "babel-cli": "^6.18.0",
-    "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
-    "babel-preset-ca": "git+ssh://git@github.com:CAAPIM/babel-preset-ca.git",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-react-hmre": "^1.1.1",
-    "babel-runtime": "^6.18.0",
     "baggage-loader": "^0.2.4",
     "browser-sync": "^2.18.2",
     "browser-sync-webpack-plugin": "^1.1.3",
@@ -53,7 +47,9 @@
     "webpack": "*"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",
+    "babel-preset-ca": "git+ssh://git@github.com:CAAPIM/babel-preset-ca.git",
     "codecov": "^1.0.1",
     "commitizen": "^2.8.6",
     "cz-conventional-changelog": "^1.2.0",
@@ -73,7 +69,6 @@
     "lint": "eslint ./src/ --ext .js",
     "flow": "flow",
     "build": "babel src --out-dir lib",
-    "install": "npm run build",
     "test:acceptance": "cd tests/acceptance; webpack --bail; NODE_ENV=production webpack --bail",
     "test:unit": "jest",
     "test:coverage": "jest --coverage",

--- a/src/loaders/loaders/js.js
+++ b/src/loaders/loaders/js.js
@@ -4,28 +4,11 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+// TODO: Add HMR without overriding user defined babel configs
 export default function (options) {
-  const presets = [];
-
-  presets.push('ca');
-
-  if (options.react) {
-    presets.push('react');
-  }
-
-  if (options.react && options.hot) {
-    presets.push('react-hmre');
-  }
-
-  const config = {
-    presets,
-  };
-
-  const loader = `${options.loaders.js}?${JSON.stringify(config)}`;
-
   return {
     test: /\.js$/,
-    loader,
+    loader: options.loaders.js,
     include: options.sourcePath,
   };
 }

--- a/tests/unit/loaders/loaders/js.test.js
+++ b/tests/unit/loaders/loaders/js.test.js
@@ -3,7 +3,7 @@ import loader from '../../../../src/loaders/loaders/js';
 describe('loaders/loaders/js', () => {
   let config;
 
-  it('can enable React mode', () => {
+  it('contains babel loader', () => {
     config = loader({
       react: true,
       sourcePath: 'foobar',
@@ -12,19 +12,6 @@ describe('loaders/loaders/js', () => {
       },
     });
 
-    expect(config.loader).toContain('react');
-  });
-
-  it('can enable HMR', () => {
-    config = loader({
-      react: true,
-      hot: true,
-      sourcePath: 'foobar',
-      loaders: {
-        js: 'babel',
-      },
-    });
-
-    expect(config.loader).toContain('react-hmre');
+    expect(config.loader).toContain('babel');
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
re-organized babel dependenciesand removed babel preset for react and HMR because they are no longer maintained.

## Impacted Areas in Application

* JS loader (babel)
* React HMR

## TODO

Add option to have HMR when `development` mode is active, without overriding user defined babel configs (via `.babelrc`). Will open a separate PR for this.