### PR TITLE
feat: allow dev server to use SSL

### DIFF
--- a/src/plugins/browserSync.js
+++ b/src/plugins/browserSync.js
@@ -6,6 +6,10 @@
 
 import BrowserSyncPlugin from 'browser-sync-webpack-plugin';
 
+// detect if --https option was passed to Webpack Dev Server
+const isWebpackDevServer = process.argv[1].indexOf('webpack-dev-server') !== -1;
+const isSSL = isWebpackDevServer && process.argv.indexOf('--https') !== -1;
+
 export default new BrowserSyncPlugin(
   // BrowserSync options
   {
@@ -14,7 +18,8 @@ export default new BrowserSyncPlugin(
     port: process.env.BS_PORT || 3000,
     // proxy the Webpack Dev Server endpoint
     // through BrowserSync
-    proxy: `http://localhost:${process.env.WDS_PORT || 8080}`,
+    proxy: `http${isSSL ? 's' : ''}://localhost:${process.env.WDS_PORT || 8080}`,
+    https: isSSL,
   },
   // plugin options
   {

--- a/tests/unit/browserSync-https.test.js
+++ b/tests/unit/browserSync-https.test.js
@@ -6,15 +6,22 @@
 
 import BrowserSyncPlugin from 'browser-sync-webpack-plugin';
 
-process.argv = ['', 'webpack-dev-server'];
+jest.mock('browser-sync-webpack-plugin');
+
+process.argv = ['', 'webpack-dev-server', '--https'];
 const config = require('../../src/browserSync').default;
 
-describe('browserSync config with webpack-dev-server', () => {
+describe('browserSync config with SSL', () => {
   it('will export an instance of webpack-config', () => {
     expect(typeof config.merge).toBe('function');
   });
 
   it('should contain BrowserSyncPlugin plugin', () => {
     expect(config.plugins[0]).toBeInstanceOf(BrowserSyncPlugin);
+  });
+
+  it('should set https to true in BrowserSync plugin', () => {
+    expect(BrowserSyncPlugin).toHaveBeenCalledTimes(1);
+    expect(BrowserSyncPlugin.mock.calls[0][0].https).toBe(true);
   });
 });

--- a/tests/unit/browserSync.test.js
+++ b/tests/unit/browserSync.test.js
@@ -6,12 +6,12 @@
 
 import config from '../../src/browserSync';
 
-describe('browserSync config without watch mode', () => {
+describe('browserSync config without using webpack-dev-server', () => {
   it('will export an instance of webpack-config', () => {
     expect(typeof config.merge).toBe('function');
   });
 
-  it('will contain no plugins if in development', () => {
+  it('will contain no plugins', () => {
     expect(config.plugins.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
Allow SSL by calling `webpack-dev-server` with the --http option
```sh
webpack-dev-server -d --https
```

## Impacted Areas in Application

* BrowserSync plugin
