### PR TITLE
feat: remove concatModule due to issues, fixed test and upgraded webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autoprefixer": "7.2.5",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
-    "browser-sync": "2.23.6",
+    "browser-sync": "^2.24.7",
     "browser-sync-webpack-plugin": "1.2.0",
     "css-loader": "0.28.9",
     "dotenv-webpack": "1.5.5",
@@ -29,10 +29,10 @@
     "flow-bin": "0.48.0",
     "flow-status-webpack-plugin": "0.1.7",
     "html-loader": "0.5.5",
-    "image-webpack-loader": "4.0.0",
+    "image-webpack-loader": "^4.3.1",
     "imagemin": "^5.3.1",
     "json-loader": "^0.5.7",
-    "node-sass": "4.7.2",
+    "node-sass": "^4.9.3",
     "postcss-loader": "2.0.10",
     "react-svg-loader": "2.1.0",
     "sass-loader": "6.0.6",
@@ -43,14 +43,14 @@
     "webpack-config": "7.5.0"
   },
   "peerDependencies": {
-    "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.11.1"
+    "webpack": "^3.12.0",
+    "webpack-dev-server": "^2.11.3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-preset-ca": "^1.1.0",
-    "codecov": "3.0.0",
+    "codecov": "^3.1.0",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "2.1.0",
     "decamelize": "2.0.0",
@@ -60,7 +60,7 @@
     "flow-coverage-report": "^0.4.1",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
-    "jest": "22.1.4",
+    "jest": "23.5.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "rimraf": "2.6.2",

--- a/src/production.js
+++ b/src/production.js
@@ -25,6 +25,5 @@ export default new Config().merge({
         ascii_only: true,
       },
     }),
-    new webpack.optimize.ModuleConcatenationPlugin(),
   ] : [],
 });

--- a/tests/unit/production-prod.test.js
+++ b/tests/unit/production-prod.test.js
@@ -17,6 +17,5 @@ describe('production config in production mode', () => {
   it('should contain UglifyJsPlugin plugin if in production', () => {
     expect(config.plugins[0]).toBeInstanceOf(webpack.DefinePlugin);
     expect(config.plugins[1]).toBeInstanceOf(webpack.optimize.UglifyJsPlugin);
-    expect(config.plugins[2]).toBeInstanceOf(webpack.optimize.ModuleConcatenationPlugin);
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
Removing ModuleConcatenationPlugin as it is causing conflicts with upgrading to the latest version of Mineral UI, due to the way it handle scope hoisting, this conflict can be resolved by avoiding this plugin for the time being, until a better solution comes along.

Potential future resolutions: Update to webpack 4 and separate the way webpack and babel handle packages, separately.